### PR TITLE
possibility to add auth key id (hash only) from cert public key info

### DIFF
--- a/kcrypto/src/main/kotlin/org/bouncycastle/kcrypto/cert/dsl/ExtensionsDsl.kt
+++ b/kcrypto/src/main/kotlin/org/bouncycastle/kcrypto/cert/dsl/ExtensionsDsl.kt
@@ -110,6 +110,10 @@ fun ExtensionsBody.authorityKeyIdentifierExtension(block: ExtAuthorityKeyId.() -
     {
         e.extValue = extUtils.createAuthorityKeyIdentifier(SubjectPublicKeyInfo.getInstance((ea.authorityKey as VerificationKey).encoding))
     }
+    else if (ea.authorityKey is SubjectPublicKeyInfo)
+    {
+        e.extValue = extUtils.createAuthorityKeyIdentifier(ea.authorityKey as SubjectPublicKeyInfo)
+    }
     else
     {
         throw IllegalArgumentException("unknown authorityKey type")


### PR DESCRIPTION
If we just have the CA cert and private key this makes it a little bit easier